### PR TITLE
syntax error at copy.js's config sample

### DIFF
--- a/copy.js
+++ b/copy.js
@@ -63,7 +63,7 @@ liberator.globalVariables.copy_templates = [
   { label: 'title',          value: '%TITLE%', map: ',y' },
   { label: 'anchor',         value: '<a href="%URL%">%TITLE%</a>' },
   { label: 'selanchor',      value: '<a href="%URL%" title="%TITLE%">%SEL%</a>' },
-  { label: 'htmlblockquote', value: '<blockquote cite="%URL%" title="%TITLE%">%HTMLSEL%</blockquote>' }
+  { label: 'htmlblockquote', value: '<blockquote cite="%URL%" title="%TITLE%">%HTMLSEL%</blockquote>' },
   { label: 'ASIN',   value: 'copy ASIN code from Amazon', custom: function(){return content.document.getElementById('ASIN').value;} },
 ];
 EOM


### PR DESCRIPTION
copy.js has syntax error at config's sample.
please see my commit and pull.
# もしくはてらまこさんに電話して無理にでも取り込ませる
