### PR TITLE
direct_bookmark.js: post to next SBM even if current SBM fail

### DIFF
--- a/direct_bookmark.js
+++ b/direct_bookmark.js
@@ -719,7 +719,9 @@ for Migemo search: require XUL/Migemo Extension
                     isNormalize ? getNormalizedPermalink(url) : url,title,
                     comment,tags
                 //));
-                ));
+                )).error(function() {
+                    throw services[service].description + ": failed"
+                });
                 if(echoType == "multiline") {
                     d = d.next(function(){
                         liberator.echo("[" + services[service].description + "] post completed.");


### PR DESCRIPTION
どれか１つサービスの投稿処理がこけると次以降のサービスの投稿処理がされません。
anekosさんにアドバイスもらいながらへぼへぼと直しました。
遅くなってスミマセン。
