### PR TITLE
Add support for QuickMarks into opener.js

### DIFF
--- a/opener.js
+++ b/opener.js
@@ -116,4 +116,16 @@ let INFO =
     );
   }
 
+  U.around(
+    quickmarks,
+    'jumpTo',
+    function (next, args) {
+      let qmark = args[0];
+      let url = quickmarks._qmarks.get(qmark);
+      if (!(url && jump(url))) {
+        return next();
+      }
+    }
+  );
+
 })();


### PR DESCRIPTION
QuickMarkでURLを開く際にも、URLがすでに開かれている場合にはそのタブに移動します。
