### PR TITLE
fix E4X for vimperator 3.6+

### DIFF
--- a/statusline-toolbar.js
+++ b/statusline-toolbar.js
@@ -39,7 +39,8 @@ var updater = {
     }
   ],
 };
-var css = <css><![CDATA[
+var css = xml`
+<css><![CDATA[
   #liberator-customize-toolbar {
     border: none !important;
     min-width: 5px !important;
@@ -49,18 +50,18 @@ var css = <css><![CDATA[
   #liberator-customize-toolbar .statusbar-resizerpanel { display: none; }
   #liberator-customize-toolbar toolbarbutton { padding: 0 !important; }
   #status-bar { background-color: transparent !important; }
-]]></css>.toString() +
+]]></css>`.toString() +
 ({
-  WINNT: <css></css>,
-  Linux: <css></css>,
-  Darwin: <css><![CDATA[
+  WINNT: xml`<css></css>`,
+  Linux: xml`<css></css>`,
+  Darwin: xml`<css><![CDATA[
     #liberator-customize-toolbar toolbarbutton {
       background: transparent !important;
       border: none !important;
       margin: 0 !important;
       padding: 0 !important;
     }
-  ]]></css>
+  ]]></css>`
 })[Cc["@mozilla.org/xre/app-info;1"].getService(Ci.nsIXULRuntime).OS].toString();
 
 function $(id) document.getElementById(id);


### PR DESCRIPTION
statusline-toolbar.jsがFirefox20でエラーでていたので修正しました。
