### PR TITLE
readitlater.js: readitlater changes its domain to getpocket.com

### DIFF
--- a/readitlater.js
+++ b/readitlater.js
@@ -281,7 +281,7 @@ let PLUGIN_INFO = xml`
 		// document => http://readitlaterlist.com/api/docs#get
 
 		let manager = Components.classes["@mozilla.org/login-manager;1"].getService(Components.interfaces.nsILoginManager);
-		let logins = manager.findLogins({},"http://readitlaterlist.com","",null);
+		let logins = manager.findLogins({},"http://getpocket.com","",null);
 
 		let req = new libly.Request(
 			"https://readitlaterlist.com/v2/get" , // url


### PR DESCRIPTION
Hi,

"readitlater" changes its domain to "getpocket.com",
so the script "readitlater.js" needs to get username and password from new domain.
Otherwise it will not work if you login from the new domain "getpocket.com".

Best regards,
Powen
