### PR TITLE
readitlater/getpocket: Looks for login credentials under HTTPS site as well as HTTP site

### DIFF
--- a/readitlater.js
+++ b/readitlater.js
@@ -277,11 +277,16 @@ let PLUGIN_INFO = xml`
 
 		}, // }}}
 
+		getLogins : function() {
+			let manager = Components.classes["@mozilla.org/login-manager;1"].getService(Components.interfaces.nsILoginManager);
+			return manager.findLogins({},"https://getpocket.com","",null).concat(
+			       manager.findLogins({}, "http://getpocket.com","",null))
+		},
+
 		get : function(state, callback){ // {{{
 		// document => http://readitlaterlist.com/api/docs#get
 
-		let manager = Components.classes["@mozilla.org/login-manager;1"].getService(Components.interfaces.nsILoginManager);
-		let logins = manager.findLogins({},"http://getpocket.com","",null);
+		let logins = this.getLogins();
 
 		let req = new libly.Request(
 			"https://readitlaterlist.com/v2/get" , // url
@@ -316,8 +321,7 @@ let PLUGIN_INFO = xml`
 
 		add : function(url,title,callback){ // {{{
 
-		let manager = Components.classes["@mozilla.org/login-manager;1"].getService(Components.interfaces.nsILoginManager);
-		let logins = manager.findLogins({},"http://getpocket.com","",null);
+		let logins = this.getLogins();
 		let req = new libly.Request(
 			"https://readitlaterlist.com/v2/add" , // url
 			null, // headers


### PR DESCRIPTION
The readitlater/getpocket plugin looks for getpocket credentials in Firefox's Password Manager under the site "http://getpocket.com". I have mine stored in "https://getpocket.com", however.

This pull request changes the plugin to search for credentials under both "http://getpocket.com" and "https://getpocket.com".
