### PR TITLE
alert.js: 「13:30」などのフォーマットで指定することで時刻を指定出来るようにしました

### DIFF
--- a/alert.js
+++ b/alert.js
@@ -350,8 +350,9 @@ let PLUGIN_INFO = xml`
   }
 
   function torelativetime(h, m) {
-    if (h < 0 || h > 24 || m < 0 || m > 59)
+    if (m > 59)
       return false;
+    h %= 24;
     var now = new Date();
     var d = (h * 60 + parseInt(m)) - (now.getHours() * 60 + now.getMinutes() + now.getSeconds() / 60);
     return d >= 0 ? d : d + 60 * 24;


### PR DESCRIPTION
時間、分のコンマ区切りで渡す事でその時刻にアラートするように設定できます
その時刻までの時間を計算して分指定の挙動に合わせています
同日中のすでに過ぎた時刻を指定した場合は翌日の時刻を指定したことになります
例 14日23時10分 に「1:00」でセット→15日1時00分にアラート
