### PR TITLE
fix "TypeError: ['@@iterator'] is not a function" on Firefox 34

### DIFF
--- a/_libly.js
+++ b/_libly.js
@@ -280,7 +280,7 @@ libly.$U = {//{{{
             }
             original = obj[name];
             let current = obj[name] = function () {
-                let self = this, args = arguments;
+                let self = this, args = Array.from(arguments);
                 return func.call(self, function (_args) original.apply(self, _args || args), args);
             };
             libly.$U.extend(current, {original: original && original.original || original, restore: restore});


### PR DESCRIPTION
Firefox 34.0で、_libly.js の around 関数を使用したプラグイン(特に`feedSomeKeys_3.js`はキー操作を受け付けなくなります)で

```
TypeError: ['@@iterator'] is not a function
```

が発生するのを修正しました。
参考: https://github.com/mooz/keysnail/issues/151
