### PR TITLE
Add a global variable to hide panel on stella.js

### DIFF
--- a/stella.js
+++ b/stella.js
@@ -2149,6 +2149,8 @@ Thanks:
     },
 
     enable: function () {
+      if (liberator.globalVariables.stella_hidden_panel === true)
+        return;
       if (this.noGUI)
         return;
       this.hidden = false;


### PR DESCRIPTION
I added a setting by using global variable to hide panel on stella.js.

``` js
liberator.globalVariables.stella_hidden_panel = true
```

At first, I thought that all change will be done if I comment in `this.noGUI = true`, but it did not work.
https://github.com/vimpr/vimperator-plugins/blob/master/stella.js#L1876
