### PR TITLE
Fix TypeError in opener.js

### DIFF
--- a/opener.js
+++ b/opener.js
@@ -42,9 +42,9 @@ let INFO = xml`
 (function () {
   let U = liberator.plugins.libly.$U;
 
-  function jump (url) {
+  function jump (_url) {
     let index = 0;
-    let url = util.stringToURLArray(url).toString();
+    let url = util.stringToURLArray(_url).toString();
     if (url == buffer.URL){
       return false;
     }


### PR DESCRIPTION
```
TypeError: redeclaration of formal parameter url
```

ってエラーが出ていたのでとりあえず出なくしました。
中身について把握していないので変数名が適当です。適切な変数名わかる方がいたら教えてください(もしくは直接直してこのPR閉じてもらっても構わないです)。