### PR TITLE
asdfghjkl.js: fix block syntax errors

### DIFF
--- a/asdfghjkl.js
+++ b/asdfghjkl.js
@@ -97,11 +97,12 @@ let PLUGIN_INFO = xml`
 
   function around (obj, name, func) {
     let next = obj[name];
-    obj[name] = function ()
+    obj[name] = function () {
       let (self = this, args =  Array.from(arguments))
         func.call(self,
                   function () next.apply(self, args),
                   args);
+    }
   }
 
   around(events, 'onKeyPress', function (next, [event]) {

--- a/asdfghjkl.js
+++ b/asdfghjkl.js
@@ -98,10 +98,10 @@ let PLUGIN_INFO = xml`
   function around (obj, name, func) {
     let next = obj[name];
     obj[name] = function () {
-      let (self = this, args =  Array.from(arguments))
-        func.call(self,
-                  function () next.apply(self, args),
-                  args);
+      let args = Array.from(arguments);
+      func.call(this,
+                () => next.apply(this, args),
+                args);
     }
   }
 


### PR DESCRIPTION
Got a syntax error when running the `asdfghjkl.js` plugin on Firefox 41.0.2 / Vimperator 3.10.1:

    Sourcing file failed: ${HOME}/.vimperator/plugin/asdfghjkl.js:101: SyntaxError: expected expression, got keyword 'let'

This change attempts to fix the syntax error. Additionally, it also removes a `let` block which is described as non-standard and not recommended here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#Non-standard_let_extensions.