### PR TITLE
suppress error "this.iteritems is not a function"

### DIFF
--- a/twittperator.js
+++ b/twittperator.js
@@ -2496,7 +2496,7 @@ let INFO = xml`
   // アクセストークン取得後 {{{
   function setup() {
     function findSubCommand(s) { // {{{
-      for (let [, cmd] in util.Array(SubCommands)) {
+      for (let [, cmd] in util.Array.iteritems(SubCommands)) {
         let m = cmd.match(s);
         if (m)
           return [cmd, m];


### PR DESCRIPTION
When call any subCommand, echo error "this.iteritems is not a function".
So I found _util.Array(ary)_ fail but _util.Array.iteritems(ary)_ succeed.