### PR TITLE
fixe migemized_find.js for xulmigemo 0.14.0

### DIFF
--- a/migemized_find.js
+++ b/migemized_find.js
@@ -103,10 +103,6 @@ let INFO = xml`
 
 (function () {
 
-  let XMigemoCore = Components.classes['@piro.sakura.ne.jp/xmigemo/factory;1']
-                     .getService(Components.interfaces.pIXMigemoFactory)
-                     .getService(liberator.globalVariables.migemized_find_language || 'ja');
-
   let colors = {
     white: '#ffffff',
     whitesmoke: '#f5f5f5',


### PR DESCRIPTION
```
migemized_find.js:106: TypeError: Components.classes["@piro.sakura.ne.jp/xmigemo/factory;1"] is undefined
```
xulmigemoを0.14.0以降にバージョンアップすると上記エラーが出るので修正しました。

-----
Vimperator:	3.13.1 (created: 2016/05/04 01:34:00)
Firefox:	Mozilla/5.0 (X11; Linux x86_64; rv:46.0) Gecko/20100101 Firefox/46.0