### PR TITLE
Fix #117: PDF.js.js cannot be loaded

### DIFF
--- a/PDF.js.js
+++ b/PDF.js.js
@@ -74,7 +74,7 @@ var INFO = xml`
       action,
       {
         count: true,
-        matchingUrls: /\.pdf$/
+        matchingUrls: /\.pdf(\?[^=]+=[^&]*)?(&[^=]+=[^&]*)*$/
       }
     );
   }


### PR DESCRIPTION
Change matchingUrls to support urls with parameters.

Signed-off-by: jensenzhang <jingxuan.n.zhang@gmail.com>